### PR TITLE
Add player object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ end
 
 group :test do
   gem 'byebug'
+  gem 'faker'
   gem 'rack-test'
   gem 'rspec'
   gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 ruby '2.4.2'
 
+gem 'activesupport'
 gem 'dotenv', groups: [:development, :test]
 gem 'faye-websocket'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     byebug (9.1.0)
@@ -18,6 +23,7 @@ GEM
     hashdiff (0.3.7)
     i18n (0.9.3)
       concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
     mustermann (1.0.2)
     public_suffix (3.0.0)
     puma (3.10.0)
@@ -49,7 +55,10 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.1)
       tilt (~> 2.0)
+    thread_safe (0.3.6)
     tilt (2.0.8)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     webmock (3.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -62,6 +71,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   byebug
   dotenv
   faker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,15 +4,20 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     byebug (9.1.0)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     dotenv (2.2.1)
     eventmachine (1.2.5)
+    faker (1.8.7)
+      i18n (>= 0.7)
     faye-websocket (0.10.7)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     hashdiff (0.3.7)
+    i18n (0.9.3)
+      concurrent-ruby (~> 1.0)
     mustermann (1.0.2)
     public_suffix (3.0.0)
     puma (3.10.0)
@@ -59,6 +64,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   dotenv
+  faker
   faye-websocket
   puma
   rack-test

--- a/app/app.rb
+++ b/app/app.rb
@@ -1,4 +1,5 @@
-%w[require_all puma sinatra faye/websocket].each { |library| require library }
+%w[require_all active_support/core_ext/object/json
+   puma sinatra faye/websocket].each { |library| require library }
 ENV['RACK_ENV'] ||= 'development'
 require 'rubygems' unless defined?(Gem)
 require 'bundler/setup'

--- a/app/lib/player.rb
+++ b/app/lib/player.rb
@@ -1,0 +1,13 @@
+module Hammeroids
+  # Server-side representation of a player
+  class Player
+    def initialize(ws, name: 'Guest')
+      @ws = ws
+      @name = name
+    end
+
+    def id
+      @ws.object_id
+    end
+  end
+end

--- a/spec/lib/player_spec.rb
+++ b/spec/lib/player_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe Hammeroids::Player do
+  describe '#to_json' do
+    subject { described_class.new(ws, name: name).to_json }
+
+    context 'socket' do
+      let(:ws) { instance_double('Faye::WebSocket', object_id: SecureRandom.uuid) }
+
+      context 'name' do
+        let(:name) { Faker::Simpsons.character }
+
+        it 'should return a String' do
+          expect(subject).to be_kind_of(String)
+        end
+
+        it 'should contain name and WS object' do
+          player_json = JSON.parse(subject)
+          expect(player_json.keys).to include 'name', 'ws'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?

Installs `Faker` for better random test data generation.

Install `ActiveSupport` and requires just core extensions for object serialisation to easily serialize objects to JSON.

Adds a really basic Player object and spec, it's not actually used anywhere yet though.

##### Background context

We need a better way to store player state server-side so i can extract that behaviour from middleware.

#### Where should the reviewer start?

`Player`

#### How should this be manually tested?

Not actually used yet.

#### Screenshots

N/A