### PR TITLE
Add rubocop config.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,68 @@
+AllCops:
+  Exclude:
+    - 'bin/**/*'
+    - 'db/**/*'
+    - vendor/**/*
+  TargetRubyVersion: 2.6
+Layout/DotPosition:
+  EnforcedStyle: "trailing"
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+  Enabled: true
+Metrics/AbcSize:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+  Max: 20
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+    - 'config/routes.rb'
+  Enabled: true
+Metrics/ClassLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+  Enabled: true
+Metrics/LineLength:
+  Max: 100
+Metrics/LineLength:
+  Include:
+    - 'spec/**/*'
+    - 'test/**/*'
+  Max: 130
+Metrics/MethodLength:
+  Exclude:
+    - 'test/**/*'
+Naming/UncommunicativeMethodParamName:
+  Exclude:
+    - 'test/**/*'
+    - 'spec/**/*'
+Style/AndOr:
+  Exclude:
+    - 'app/controllers/**/*'
+Style/ClassAndModuleChildren:
+  Include:
+    - 'app/controllers/**/*'
+  Enabled: false
+Style/Documentation:
+  Exclude:
+    - 'app/controllers/**/*'
+    - 'app/helpers/**/*'
+    - 'app/mailers/**/*'
+    - 'app/models/**/*'
+    - 'app/serializers/**/*'
+    - 'config/**/*'
+    - 'spec/**/*'
+    - 'test/**/*'
+  Enabled: true
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/SignalException:
+  Exclude:
+    - 'Dangerfile'
+Style/StringLiterals: 
+  EnforcedStyle: "double_quotes"


### PR DESCRIPTION
#### What's this PR do?

Install rubocop `gem install rubocop` and configure linter in chosen
editor.

##### Background context

Best to have some standards.