### PR TITLE
Remove duplicate player creation

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -23,7 +23,6 @@ module Hammeroids
         EventMachine::WebSocket.start(host: @socket_host, port: @socket_port) do |ws|
 
           ws.onopen do |handshake|
-            player = Hammeroids::Player.new.create
             lobby = Hammeroids::Lobby.new
             ws.send(lobby.to_json)
           end


### PR DESCRIPTION
#### What's this PR do?
Creates only one player when the game page is loaded
Removed player creation on socket connect

##### Background context
Two players were being created every time a user connected.

#### How should this be manually tested?
Join the app, check the console, there should be only one player listed
