### PR TITLE
Added Sprockets for interpolating ENV variables in JS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'thin'
 gem "redis"
 gem 'require_all'
 gem 'sinatra'
+gem 'sprockets', '~> 3.5', '>= 3.5.2'
 
 group :development do
   gem 'racksh'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,9 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.5)
       tilt (~> 2.0)
+    sprockets (3.7.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -85,6 +88,7 @@ DEPENDENCIES
   require_all
   rspec
   sinatra
+  sprockets (~> 3.5, >= 3.5.2)
   thin
   webmock
 

--- a/app/app.rb
+++ b/app/app.rb
@@ -60,8 +60,8 @@ module Hammeroids
     set :root, File.join(File.dirname(__FILE__), '..')
     set :logging, true
     set :views, File.join(File.dirname(__FILE__), 'views')
-    set :public_folder, File.dirname(__FILE__) + '/assets'
     set :static, true
+    
 
     configure :development do
       require 'dotenv/load'
@@ -75,6 +75,12 @@ module Hammeroids
 
     configure :production do
       enable :logging
+    end
+
+    get '/js/*' do
+      environment = Sprockets::Environment.new
+      environment.append_path 'app/assets'
+      environment.call(env)
     end
 
     get '/' do

--- a/app/assets/js/Sockets.js.erb
+++ b/app/assets/js/Sockets.js.erb
@@ -1,7 +1,7 @@
 var Sockets = function(){
 	var scheme = "ws://",
-		uri = scheme + window.document.location.host + ':8080' + '/game',
-		ws = new WebSocket("ws://localhost:8080/game"),
+		uri = scheme + window.document.location.host + "<%= ENV['SOCKET_PORT'] %>" + '/game',
+		ws = new WebSocket("ws://localhost:<%= ENV['SOCKET_PORT']%>/game"),
 		networkObjects = [];
 
 	function updatePlayerShipState(playerShipState){


### PR DESCRIPTION
#### What's this PR do?
Adds Sprockets so ENV vars can be interpolated

##### Background context
Port for websocket was hard-coded and shouldn't be

#### Where should the reviewer start?
gemfile - added sprockets
app.rb - removed 'assets' from public folder, added 'js' get directive
sockets.js.erb - added erb interpolation of ENV vars
