### PR TITLE
Return empty pack path in test environment.

### DIFF
--- a/app/initializers/webpack.rb
+++ b/app/initializers/webpack.rb
@@ -5,7 +5,7 @@ class Webpack
   }.freeze
 
   def self.pack_location
-    LOCATIONS.fetch(environment.to_sym)
+    LOCATIONS.fetch(environment.to_sym, nil)
   end
 
   def self.environment


### PR DESCRIPTION
#### What's this PR do?

If/when we add feature specs this will probably need to return
something, but at the moment causes tests to fail.

##### Background context

I didn't run the tests when i made this change, we need to integrate CI into PR hooks.
